### PR TITLE
Fix small bugs in the patch recovery code

### DIFF
--- a/CoCoNut/tokenization/tokenization.py
+++ b/CoCoNut/tokenization/tokenization.py
@@ -236,8 +236,40 @@ def token2statement(token_list, numbers, strings):
                     for s in range(0, len(statements)):
                         statements[s] += token + " "
         else:  # no space after the last statement
-            for s in range(0, len(statements)):
-                statements[s] += token
+            if token_list[i] == "$STRING$":
+                if flag_string_statements == 3:
+                    for s in range(0, len(statements)):
+                        if "'" not in strings[s % len(strings)]:
+                            statements[s] += "'" + strings[s % len(strings)] + "'"
+                        else:
+                            statements[s] += '"' + strings[s % len(strings)] + '"'
+                elif flag_string_statements == 1:
+                    for s in range(0, len(statements)):
+                        if "'" not in strings[s]:
+                            statements[s] += "'" + strings[s] + "'"
+                        else:
+                            statements[s] += '"' + strings[s] + '"'
+                else:
+                    for s in range(0, len(statements)):
+                        statements[s] += "'DEFAULT'"
+            elif token_list[i] == "$NUMBER$":
+                if flag_string_statements == 3:
+                    count = 0
+                    for s in range(0, len(numbers)):
+                        for stringlen in range(s, s + len(strings)):
+                            statements[count] += numbers[s]
+                            count += 1
+                elif flag_string_statements == 2:
+                    for s in range(0, len(statements)):
+                        statements[s] += numbers[s]
+                else:
+                    # use default number 2 (0 and 1 are specific tokens)
+                    statements[s] += 2
+            elif token_list[i] == "CaMeL":  # no space
+                pass
+            else:
+                for s in range(0, len(statements)):
+                    statements[s] += token
     return statements
 
 str_re=" throw new RepositoryException(\"Could not index user to bucket \")"

--- a/Recovery_Code.py
+++ b/Recovery_Code.py
@@ -29,15 +29,27 @@ def Recovery_Tufano_one(ori_str,wordmap:dict):
         ori_str=ori_str.replace(key,reverse_map.get(key).strip())
     final_str=ori_str.replace('\n','').replace('\r','')
     return final_str
-def Recovery_CoCoNut_one(buggy_str,pred_str):
-    strings,numbers=get_strings_numbers(buggy_str)
+def Recovery_CoCoNut_one(buggy_file,pred_str):
+    strings,numbers=get_strings_numbers_from_file(buggy_file)
     recovery_tokens=pred_str.split()
     recovery_str=token2statement(recovery_tokens,numbers,strings)
     #print(recovery_str)
     if len(recovery_str)==0:
         recovery_str=[pred_str]
     return recovery_str[0]
-def Recovery_CoCoNut_all(preds_f,ids_f,buggy_lines_dir,buggy_methods_dir,output_dir,candi_size=100):
+
+def get_strings_numbers_from_file(file_path):
+    numbers_set = set()
+    strings_set = set()
+    with open(file_path, 'r') as file:
+        data = file.readlines()
+        for _, line in enumerate(data):
+            strings, numbers = get_strings_numbers(line)
+            numbers_set.update(numbers)
+            strings_set.update(strings)
+    return list(strings_set), list(numbers_set)
+
+def Recovery_CoCoNut_all(preds_f,ids_f,buggy_lines_dir,buggy_methods_dir,buggy_classes_dir,output_dir,candi_size=100):
     ids=readF2L(ids_f)
     preds=readF2L(preds_f)
     assert len(preds) % (candi_size + 2) == 0
@@ -52,7 +64,7 @@ def Recovery_CoCoNut_all(preds_f,ids_f,buggy_lines_dir,buggy_methods_dir,output_
         patches_dict=dict()
         for pid,pred in enumerate(group[2:]):
             pred=pred.split('\t')[-1]
-            rec_line=Recovery_CoCoNut_one(id_buggyline,pred)
+            rec_line=Recovery_CoCoNut_one(buggy_classes_dir+'/'+id+'.java',pred)
             rec_method=id_buggymethod.replace(id_buggyline,rec_line)
             patches_dict[str(pid)]=rec_method
         with open(output_dir+'/'+id+'.txt','w',encoding='utf8')as f:


### PR DESCRIPTION
1. Replace abstracted tokens with donor code from the buggy java file instead of the buggy line.
2. Fix the bug that the last abstracted token is not replaced.